### PR TITLE
Added an if statement to the Backup-TCBSDREPO function

### DIFF
--- a/Backup-TCBSDRepo/Backup-TCBSDRepo.psm1
+++ b/Backup-TCBSDRepo/Backup-TCBSDRepo.psm1
@@ -32,6 +32,9 @@ function Backup-TCBSDRepo {
         [ValidateScript({Test-Path $_})]
         [string]$OutputPath
     )
+    if(!$OutputPath.EndsWith('\')){
+        $OutputPath = $OutputPath + '\'
+    }
     Download-Repofiles -DownloadUrl $Url -DownloadPath $OutputPath
 }
 


### PR DESCRIPTION
The new statement adds a '\' to the end of the $OutputPath input if the user did not include one.

If a user does not add the '\' to the end of the OutputPath parameter, a new directory is created instead of using the intended directory. Now, if a user mistakenly leaves out the ending slash, it is added and prevents a new directory from being created.